### PR TITLE
Improve compat with openSUSE 15.4

### DIFF
--- a/groupware-mail/docker-compose.yml
+++ b/groupware-mail/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '3.3'
+version: '3.5'
 services:
   mariadb:
     image: docker.io/mariadb:${MARIADB_CONTAINER_VERSION}
@@ -40,7 +40,7 @@ services:
     #   - ./dovecot/dovecot-sql.conf.ext:/etc/dovecot/dovecot-sql.conf.ext
     networks:
       - hordenet
-#    entrypoint: ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+#    entrypoint: ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 #    command: ["/usr/sbin/dovecot", "-F"]
 ## Uncomment to expose imap port to all host interfaces
 #    ports:


### PR DESCRIPTION
On the newer docker-compose version of openSUSE 15.4, the name attribute for networks raises an error unless schema version is 3.5 or higher. Current Ubuntu or older openSUSE are not affected.