### PR TITLE
scripts to install dev tools manually

### DIFF
--- a/basic-setup/bin/dd-install
+++ b/basic-setup/bin/dd-install
@@ -1,0 +1,6 @@
+#!/bin/bash
+source .env
+MASTERCONTAINER="${PREFIX_CONTAINER}horde_web"
+
+CMD="composer require --dev symfony/var-dumper"
+docker exec -i "$MASTERCONTAINER" bash -c "$CMD" 

--- a/basic-setup/bin/devtools-install.sh
+++ b/basic-setup/bin/devtools-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+source .env
+MASTERCONTAINER="${PREFIX_CONTAINER}horde_web"
+stuff="vim wget"
+CMD="zypper -n install $stuff"
+docker exec -i "$MASTERCONTAINER" bash -c "$CMD" 
+echo "installing $stuff"

--- a/basic-setup/bin/global-phpunit-install.sh
+++ b/basic-setup/bin/global-phpunit-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+source .env
+MASTERCONTAINER="${PREFIX_CONTAINER}horde_web"
+
+CMD="command -v wget"
+PHPUNITVERSION="phpunit-9.phar"
+PHPUNITURL="https://phar.phpunit.de/$PHPUNITVERSION"
+
+
+if ! docker exec -i "$MASTERCONTAINER" bash -c "$CMD" &> /dev/null
+then
+    echo "wget could not be found, installing it now"
+    CMD="zypper -n install wget"
+    docker exec -i  "$MASTERCONTAINER" bash -c "$CMD"
+fi
+
+CMD="cd /usr/local/bin/ && wget -O phpunit $PHPUNITURL && chmod +x phpunit && phpunit --version"
+docker exec -i "$MASTERCONTAINER" bash -c "$CMD"

--- a/basic-setup/bin/vfsstream-install.sh
+++ b/basic-setup/bin/vfsstream-install.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+source .env
+MASTERCONTAINER="${PREFIX_CONTAINER}horde_web"
+
+
+CMD="composer require --dev mikey179/vfsstream"
+docker exec -i "$MASTERCONTAINER" bash -c "$CMD" 

--- a/basic-setup/bin/xdebug-install.sh
+++ b/basic-setup/bin/xdebug-install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+source .env
+MASTERCONTAINER="${PREFIX_CONTAINER}horde_web"
+
+CMD="zypper -n install php7-xdebug"
+docker exec -i "$MASTERCONTAINER" bash -c "$CMD" 
+echo "installing php7-xdebug"
+
+CMD="rpm -qa '*xdebug*' --qf "%{VERSION}\n" | cut -d'.' -f1"
+xdebug_major_version=$(docker exec -i "$MASTERCONTAINER" bash -c "$CMD")
+echo "xdebug major version is: $xdebug_major_version"
+    if [[ $xdebug_major_version -eq 2 ]]; then
+        # configuration for Xdebug 2.9.5 as distributed by openSUSE Leap 15.3
+        CMD='{
+            echo "xdebug.remote_enable = 1";
+            echo "xdebug.remote_autostart = 1";
+            echo "xdebug.remote_port = 9000";
+        } >> /etc/php7/conf.d/xdebug.ini';
+        docker exec -i "$MASTERCONTAINER" bash -c "$CMD"
+    elif [[ $xdebug_major_version -eq 3 ]]; then
+        # NOTE: untested as of 2022-03-04, as only Tumbleweed has Xdebug 3
+        CMD='{
+            echo "xdebug.mode = develop,debug";
+            echo "xdebug.start_with_request = yes";
+        } >> /etc/php7/conf.d/xdebug.ini'
+        docker exec -i "$MASTERCONTAINER" bash -c "$CMD"
+    fi
+    unset xdebug_major_version


### PR DESCRIPTION
I find this practical because the container setup sometimes takes to long to install all the needed dev tools.
With manual scripts one can start working and let the scripts to install all thats needed.

- also usefull so one can isntall devtools when the container itself needs debugging and devtoosl cannot be isntalled from entrypoint.sh